### PR TITLE
Minor changes to https://github.com/sampsyo/clusterfutures/pull/19

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
 
     steps:
     - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - name: Checkout

--- a/cfut/slurm.py
+++ b/cfut/slurm.py
@@ -35,6 +35,8 @@ STATES_FINISHED = {  # https://slurm.schedmd.com/squeue.html#lbAG
 }
 
 def jobs_finished(job_ids):
+    """Check which ones of the given Slurm jobs already finished
+    """
 
     # If there is no Slurm job to check, return right away
     if not job_ids:

--- a/cfut/slurm.py
+++ b/cfut/slurm.py
@@ -35,6 +35,11 @@ STATES_FINISHED = {  # https://slurm.schedmd.com/squeue.html#lbAG
 }
 
 def jobs_finished(job_ids):
+
+    # If there is no Slurm job to check, return right away
+    if not job_ids:
+        return set()
+
     res = run([
         'squeue', '--noheader', '--format=%i %T',
         '--jobs', ','.join([str(j) for j in job_ids]), '--states=all',

--- a/slurm_example.py
+++ b/slurm_example.py
@@ -7,6 +7,11 @@ def square(n):
     return n * n
 def hostinfo():
     return subprocess.check_output('uname -a', shell=True)
+def just_raise():
+    raise RuntimeError("error")
+def just_exit():
+    import sys
+    sys.exit()
 
 def example_1():
     """Square some numbers on remote hosts!
@@ -32,7 +37,25 @@ def example_3():
     exc = cfut.SlurmExecutor(False)
     print(list(cfut.map(exc, square, [5, 7, 11])))
 
+def example_4():
+    """Demonstrate the behavior in case of an error
+    """
+    with cfut.SlurmExecutor(True, keep_logs=True) as executor:
+        future = executor.submit(just_raise)
+        res = future.result()
+
+def example_5():
+    """
+    Demonstrate the behavior in case of unexpected exit
+    """
+    with cfut.SlurmExecutor(True, keep_logs=True) as executor:
+        future = executor.submit(just_exit)
+        res = future.result()
+
+
 if __name__ == '__main__':
     example_1()
     example_2()
     example_3()
+    # example_4()  # warning: this raises an exception
+    # example_5()  # warning: this takes ~30 seconds


### PR DESCRIPTION
Hi @takluyver,  I'm branching from the discussion in https://github.com/sampsyo/clusterfutures/pull/19 since it is simpler to provide feedback via another PR to your branch. As far as we are concerned, it looks like the current implementation already works as expected.

I'm proposing the minor changes listed below, but nothing is critical - I can take them back if needed or you can simply discard this PR:
1. Could we add python 3.10 to the CI? The tests pass locally, in a python3.10 environment, but I don't know if there may be some specific reason for excluding it.
2. I added two examples to `slurm_example.py`, for different failure cases.
3. I added a docstring to `jobs_finished`.
4. In `jobs_finished`, I suggest we skip the `squeue` call if there is no job to check.